### PR TITLE
Allows the user to pass a config object as the first parameter of the logs functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,6 +245,7 @@ function logWithLevel(level, message, messagetype) {
 }
 
 //region [ Logger ]
+const counts = {}
 const logger = {};
 
 /**
@@ -271,7 +272,26 @@ logger.setLevel = function setLoggingLevel(level) {
  * @param message
  */
 logger.log = function(level, message, messagetype) {
-  logWithLevel(level, message, messagetype);
+  var messageArray = [].slice.call(message);
+  var label = messageArray[0];
+  var max = Number.MAX_SAFE_INTEGER;
+
+  if(typeof label === 'object'){
+    var _label = label;
+    label = _label.label;
+    max = _label.max || max
+  }
+
+  if(!counts[label]){
+    counts[label] = 0
+  }
+
+  if(counts[label]++ >= max){
+    return;
+  }
+
+  var newMessage = [label].concat(messageArray.slice(1, messageArray.length))
+  logWithLevel(level, newMessage, messagetype);
 };
 
 /**


### PR DESCRIPTION
Hello!

First of all, thanks for the library!

This pr introduces a new feature without (hopefully) any breaking change!

I wanted to be able to limit to number of times a log would appear in the console, sometimes your component re-renders 100 times but you only need 3 or 4 props as a sample.

The current signature of the logs functions is: func(label, ...args) so I couldn't just pass another parameter to the function.

My solution: 
Allow the user to pass an object as the first argument, if the user passed an object, check if that object contains a 'max' property, if that's the case, do not output anything if max has been reached already.

Example:
```Javascript
const {logger} = require('./index')

// Will show the output 
logger.debug({label: 'my-label', max: 1}, {
  foo: 'bar'
})

// Won't log anything to the console
logger.debug({label: 'my-label', max: 1}, {
  foo: 'bar'
})

// Will log as expected since no max value has been passed
logger.debug('my-label', {
  foo: 'bar42'
})

// Same as above
logger.debug({label: my-label}, {
  foo: 'bar42'
})
```