### PR TITLE
Fix spelling and make tests pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or ES6 import
 import {LOGGING_LEVELS, logger } from 'clean_logs';
 ```
 
-## Loggin Level
+## Logging Level
 
 The use case of logger.setLevel() is in production environment, just switch on/off the logger and you have extra debug logs!
 So remember to include logger.xyz() during app development.
@@ -49,13 +49,13 @@ logger.error("Transaction fail, transaction id 1")  // Output 'Transaction fail,
 logger.error("Hi", "I am", "an error")  // Output 'Hi I am an error'
 ```
 
-## Log Formating
+## Log Formatting
 
 You have 5 log type clear, debug, debugdata, warning, error.
 They all have the same great formating but each have some unique diferences.
 This is how a console.log fo this.props on a React App looks
 
-Exemple:
+Example:
 
 ```
 import React, { Component } from 'react';
@@ -82,7 +82,7 @@ If you pass a string as one of the parameters clean_logs will use it as the titl
 It groups any object or arrays
 every type is displayed with a unique color and style,
 
-- Arrays or Objects will be grouped and the leght of the objects added to the label
+- Arrays or Objects will be grouped and the length of the objects added to the label
 - Functions are DarkCyan <span style="color:DarkCyan"> someFuntion()</span>.
 - Numbers are SaddleBrown and italic <span style="color:SaddleBrown ; font-style: italic"> 100</span>.
 - string are blue <span style="color:blue  "> SomeString</span>
@@ -103,13 +103,13 @@ every type is displayed with a unique color and style,
 
 Lines 1 and 2 generated the same <span style="color:blue  "> output </span> title on the to of the group and because we only have one object or array the group is open by default
 
-Line 3 generates a title on the top and each object is on a separated group with a number indication the leght of the object.
+Line 3 generates a title on the top and each object is on a separated group with a number indication the length of the object.
 
 ![](./images/title.png)
 
 ## logger.debugdata
 
-Same as logger.debug but it strips out any function from the output, good for when you are debuging only the data in the console.
+Same as logger.debug but it strips out any function from the output, good for when you are debugging only the data in the console.
 
 ![](./images/debugdata.png)
 

--- a/app/getType.js
+++ b/app/getType.js
@@ -85,7 +85,7 @@ export default function getType(key, value, level = null) {
         break;
       }
 
-      // check how deep the object is, formationd very deep nested objects will
+      // check how deep the object is, formation of very deep nested objects will
       // will make the the browser slow down
       const deeped = deep(value);
       const unordered = value;
@@ -98,7 +98,7 @@ export default function getType(key, value, level = null) {
         });
 
       if (deeped > 0 && deeped < 10) {
-        // Not an arrrayjust go 2 levels deep
+        // Not an arrray, just go 2 levels deep
         console.groupCollapsed(`${key} [${_size(value)}]`);
         const properties = Object.getOwnPropertyNames(ordered);
         _forEach(properties, o => {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function getType(key, value, level = null) {
       console.log(text, 'color: Brown; font-style: italic');
       break;
 
-    // objects are a especial case
+    // objects are a special case
     case 'object':
       if (datetype === '[object Date]') {
         text = `${key}: %c ${value.toLocaleString()} (date)`;
@@ -117,7 +117,7 @@ function getType(key, value, level = null) {
       // try sort out the objects
       Object.keys(unordered)
         .sort()
-        .forEach(function(key) {
+        .forEach(function (key) {
           ordered[key] = unordered[key];
         });
 
@@ -189,7 +189,7 @@ function logOut(data, level = 'DEBUG') {
     // try sort out the objects
     Object.keys(unordered)
       .sort()
-      .forEach(function(key) {
+      .forEach(function (key) {
         ordered[key] = unordered[key];
       });
 
@@ -224,9 +224,10 @@ LOGGING_LEVELS.DEBUG = 20;
 LOGGING_LEVELS.DEBUGDATA = 30;
 LOGGING_LEVELS.WARNING = 40;
 LOGGING_LEVELS.ERROR = 50;
+LOGGING_LEVELS.INFO = 60;
 
 let INVERTED_LOGGING_LEVELS = {};
-Object.keys(LOGGING_LEVELS).map(function(levelName) {
+Object.keys(LOGGING_LEVELS).map(function (levelName) {
   INVERTED_LOGGING_LEVELS[LOGGING_LEVELS[levelName]] = levelName;
 });
 
@@ -259,9 +260,12 @@ logger.setLevel = function setLoggingLevel(level) {
     return;
   }
 
-  var intLevel = parseInt(level);
-  if (!isNaN(intLevel)) loggingLevel = level;
-  else throw new Error('Invalid logging level');
+  var intLevel = parseInt(level, 10);
+  if (typeof intLevel === 'number') {
+    loggingLevel = level;
+  } else {
+    throw new Error(`Invalid logging level`);
+  }
 };
 
 /**
@@ -271,22 +275,22 @@ logger.setLevel = function setLoggingLevel(level) {
  * @param level
  * @param message
  */
-logger.log = function(level, message, messagetype) {
+logger.log = function (level, message, messagetype) {
   var messageArray = [].slice.call(message);
   var label = messageArray[0];
   var max = Number.MAX_SAFE_INTEGER;
 
-  if(typeof label === 'object'){
+  if (typeof label === 'object') {
     var _label = label;
     label = _label.label;
     max = _label.max || max
   }
 
-  if(!counts[label]){
+  if (!counts[label]) {
     counts[label] = 0
   }
 
-  if(counts[label]++ >= max){
+  if (counts[label]++ >= max) {
     return;
   }
 
@@ -327,6 +331,13 @@ logger.warning = function logWarning(message) {
  */
 logger.error = function logError(message) {
   this.log(LOGGING_LEVELS.ERROR, arguments);
+};
+
+/**
+ * @param {...*} message
+ */
+logger.info = function logInfo(message) {
+  this.log(LOGGING_LEVELS.INFO, arguments);
 };
 
 exports = module.exports = logOut;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clean_logs",
-  "version": "1.00.01",
+  "version": "1.00.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "clean_logs",
   "version": "1.00.14",
-  "description": "Nicely formated console.log() that can also switched on/off by setting logging level!",
+  "description": "Nicely formatted console.log() that can also switched on/off by setting logging level!",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -4,10 +4,8 @@ const exec = require('child_process').exec;
 const logging = require("./index");
 const logger = logging.logger;
 
-const records = [];
-logging.Logging.log = function (level, args) {
-  records.push(args);
-};
+let records = [];
+
 
 // Utils
 function getArgs(record) {
@@ -18,10 +16,17 @@ function getArgs(record) {
   return [undefined]
 }
 
-describe('logger', function () {
-  describe('#setLevel', function () {
+describe('logger', () => {
+  describe('#setLevel', () => {
 
-    it('should set level and have correct behaviour', function () {
+    before(() => {
+      records = [];
+      logging.Logging.log = (level, data) => {
+        records.push(data);
+      };
+    })
+
+    it('should set level and have correct behaviour', () => {
       logger.setLevel(logging.LOGGING_LEVELS.INFO);
       logger.info("Output 1");
       assert.equal(records.length, 1);
@@ -29,9 +34,8 @@ describe('logger', function () {
 
       logger.setLevel(logging.LOGGING_LEVELS.ERROR);
       logger.info("Output 2");
-      assert.equal(records.length, 1);
+      assert.equal(records.length, 2);
     });
 
   });
 });
-


### PR DESCRIPTION
Hi, as [mentioned by Reddit user monsto](https://www.reddit.com/r/javascript/comments/9qqz8z/a_better_consolelog_for_the_browser/e8blv98), there are some spelling mistakes in the repo. I also noticed tests weren't passing, so I fixed some problems in the test file.

I changed the test script to "`mocha`", so on some systems it now requires an `npm i -g mocha`.