### PR TITLE
Removed _isEmpty.

### DIFF
--- a/app/getType.js
+++ b/app/getType.js
@@ -1,5 +1,4 @@
 import _isNull from 'lodash/isNull';
-import _isEmpty from 'lodash/isEmpty';
 import _forEach from 'lodash/forEach';
 import _isArray from 'lodash/isArray';
 import _keys from 'lodash/keys';
@@ -79,7 +78,7 @@ export default function getType(key, value, level = null) {
         console.log(text, 'color: ForestGreen');
         break;
       }
-      if (_isEmpty(value)) {
+      if (Object.keys(value).length === 0) {
         text = `${key}: %c EMPTY`;
         console.log(text, 'color: DeepPink');
         break;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const _filter = require('lodash/filter');
 const _size = require('lodash/size');
 const _forEach = require('lodash/forEach');
 const _isNull = require('lodash/isNull');
-const _isEmpty = require('lodash/isEmpty');
 const _has = require('lodash/has');
 
 function getText(data) {
@@ -103,7 +102,7 @@ function getType(key, value, level = null) {
         console.log(text, 'color: ForestGreen');
         break;
       }
-      if (_isEmpty(value)) {
+      if (Object.keys(value).length === 0) {
         text = `${key}: %c EMPTY`;
         console.log(text, 'color: DeepPink');
         break;


### PR DESCRIPTION
Hi! I saw your library on JavaScript Daily's twitter.

While clean_logs is just a few Kb by itself, when bundled with Lodash it's over 100 Kb. It seems the size can be reduced by getting rid of Lodash and just using vanilla JS Object and Array methods.  

I removed _isEmpty as proof of concept, since it's only being used once, but (in conjunction with its own dependencies within Lodash) is hundreds of lines of code.

If you are on board with this, I'll get on removing the rest of them.

Either way, thanks for your work! =)