### PR TITLE
Feature/further lodash removal

### DIFF
--- a/app/getText.js
+++ b/app/getText.js
@@ -1,5 +1,3 @@
-import _forEach from 'lodash/forEach';
-
 export function getText(data) {
   let text = null;
   let index = null;

--- a/app/getType.js
+++ b/app/getType.js
@@ -1,4 +1,3 @@
-import _isNull from 'lodash/isNull';
 import _forEach from 'lodash/forEach';
 import _keys from 'lodash/keys';
 import _size from 'lodash/size';
@@ -66,7 +65,7 @@ export default function getType(key, value, level = null) {
         console.log(text, 'color: DarkGreen');
         break;
       }
-      if (_isNull(value)) {
+      if (value === null) {
         text = `${key}: %c NULL`;
         console.log(text, 'color: Brown; font-style: italic');
         break;

--- a/app/getType.js
+++ b/app/getType.js
@@ -1,6 +1,4 @@
 import _forEach from 'lodash/forEach';
-import _keys from 'lodash/keys';
-import _size from 'lodash/size';
 
 function deep(object) {
   var level = 1;
@@ -95,7 +93,7 @@ export default function getType(key, value, level = null) {
 
       if (deeped > 0 && deeped < 10) {
         // Not an arrray, just go 2 levels deep
-        console.groupCollapsed(`${key} [${_size(value)}]`);
+        console.groupCollapsed(`${key} [${Object.keys(value).length}]`);
         const properties = Object.getOwnPropertyNames(ordered);
         _forEach(properties, o => {
           getType(o, value[o], level);

--- a/app/getType.js
+++ b/app/getType.js
@@ -1,9 +1,7 @@
 import _isNull from 'lodash/isNull';
 import _forEach from 'lodash/forEach';
-import _isArray from 'lodash/isArray';
 import _keys from 'lodash/keys';
 import _size from 'lodash/size';
-import _has from 'lodash/has';
 
 function deep(object) {
   var level = 1;
@@ -73,7 +71,7 @@ export default function getType(key, value, level = null) {
         console.log(text, 'color: Brown; font-style: italic');
         break;
       }
-      if (_has(value, '_isAMomentObject')) {
+      if (value.hasOwnProperty('_isAMomentObject')) {
         text = `${key}: %c ${value.format('lll')} (moment)`;
         console.log(text, 'color: ForestGreen');
         break;

--- a/app/getType.js
+++ b/app/getType.js
@@ -1,5 +1,3 @@
-import _forEach from 'lodash/forEach';
-
 function deep(object) {
   var level = 1;
   var key;
@@ -95,9 +93,7 @@ export default function getType(key, value, level = null) {
         // Not an arrray, just go 2 levels deep
         console.groupCollapsed(`${key} [${Object.keys(value).length}]`);
         const properties = Object.getOwnPropertyNames(ordered);
-        _forEach(properties, o => {
-          getType(o, value[o], level);
-        });
+        properties.forEach(prop => getType(prop, value[prop], level));
         console.groupEnd();
 
         break;

--- a/app/loging.js
+++ b/app/loging.js
@@ -1,13 +1,12 @@
-import _forEach from 'lodash/forEach';
-
 import { getText } from './getText';
 import getType from './getType';
 
 function loop(data, level) {
-  if (Object.keys(data).length === 1) {
-    _forEach(data[0], (val, key) => getType(key, val, level));
+  const propNames = Object.keys(data[0]);
+  if (propNames.length === 1) {
+    getType(propNames[0], data[0][propNames[0]], level);
   } else {
-    _forEach(data, (val, key) => getType(key, val, level));
+    propNames.forEach(name => getType(name, data[0][name], level));
   }
 }
 

--- a/app/loging.js
+++ b/app/loging.js
@@ -1,13 +1,11 @@
 import _filter from 'lodash/filter';
-import _size from 'lodash/size';
-import _sortedIndexBy from 'lodash/sortedIndexBy';
 import _forEach from 'lodash/forEach';
 
 import { getText } from './getText';
 import getType from './getType';
 
 function loop(data, level) {
-  if (_size(data) === 1) {
+  if (Object.keys(data).length === 1) {
     _forEach(data[0], (val, key) => getType(key, val, level));
   } else {
     _forEach(data, (val, key) => getType(key, val, level));

--- a/app/loging.js
+++ b/app/loging.js
@@ -1,4 +1,3 @@
-import _filter from 'lodash/filter';
 import _forEach from 'lodash/forEach';
 
 import { getText } from './getText';
@@ -41,9 +40,7 @@ export default function logOut(data, level = 'DEBUG') {
 
     // removed the label from the data structure
 
-    const unordered = _filter(data, o => {
-      return o !== Label.text;
-    });
+    const unordered = data.filter(datum => datum !== Label.text);
 
     const ordered = {};
     // try sort out the objects

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
-const _forEach = require('lodash/forEach');
-
 const getText = (data) => {
   let text = null;
   let index = null;
-  _forEach(data, (val, key) => {
+  data.forEach((val, key) => {
     if (text === null && typeof val === 'string') {
       text = val;
       index = key;
@@ -120,9 +118,7 @@ function getType(key, value, level = null) {
         // Not an arrrayjust go 2 levels deep
         console.groupCollapsed(`${key} [${Object.keys(value).length}]`);
         const properties = Object.getOwnPropertyNames(ordered);
-        _forEach(properties, o => {
-          getType(o, value[o], level);
-        });
+        properties.forEach(prop => getType(prop, value[prop], level));
         console.groupEnd();
 
         break;
@@ -140,10 +136,11 @@ function getType(key, value, level = null) {
 }
 
 function loop(data, level) {
-  if (Object.keys(data).length === 1) {
-    _forEach(data[0], (val, key) => getType(key, val, level));
+  const propNames = Object.keys(data[0]);
+  if (propNames.length === 1) {
+    getType(propNames[0], data[0][propNames[0]], level);
   } else {
-    _forEach(data, (val, key) => getType(key, val, level));
+    propNames.forEach(name => getType(name, data[0][name], level));
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const _filter = require('lodash/filter');
 const _size = require('lodash/size');
 const _forEach = require('lodash/forEach');
-const _isNull = require('lodash/isNull');
 
 function getText(data) {
   let text = null;
@@ -91,7 +90,7 @@ function getType(key, value, level = null) {
         console.log(text, 'color: DarkGreen');
         break;
       }
-      if (_isNull(value)) {
+      if (value === null) {
         text = `${key}: %c NULL`;
         console.log(text, 'color: Brown; font-style: italic');
         break;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const _filter = require('lodash/filter');
 const _size = require('lodash/size');
 const _forEach = require('lodash/forEach');
 const _isNull = require('lodash/isNull');
-const _has = require('lodash/has');
 
 function getText(data) {
   let text = null;
@@ -97,7 +96,7 @@ function getType(key, value, level = null) {
         console.log(text, 'color: Brown; font-style: italic');
         break;
       }
-      if (_has(value, '_isAMomentObject')) {
+      if (value.hasOwnProperty('_isAMomentObject')) {
         text = `${key}: %c ${value.format('lll')} (moment)`;
         console.log(text, 'color: ForestGreen');
         break;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
-const _filter = require('lodash/filter');
 const _forEach = require('lodash/forEach');
 
-function getText(data) {
+const getText = (data) => {
   let text = null;
   let index = null;
   _forEach(data, (val, key) => {
@@ -11,7 +10,7 @@ function getText(data) {
     }
   });
   return { text, index };
-}
+};
 
 function deep(data) {
   let object = {};
@@ -177,9 +176,7 @@ function logOut(data, level = 'DEBUG') {
 
     // removed the label from the data structure
 
-    const unordered = _filter(data, o => {
-      return o !== Label.text;
-    });
+    const unordered = data.filter(datum => datum !== Label.text);
 
     const ordered = {};
     // try sort out the objects

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const _filter = require('lodash/filter');
-const _size = require('lodash/size');
 const _forEach = require('lodash/forEach');
 
 function getText(data) {
@@ -120,7 +119,7 @@ function getType(key, value, level = null) {
 
       if (deeped > 0 && deeped < 5) {
         // Not an arrrayjust go 2 levels deep
-        console.groupCollapsed(`${key} [${_size(value)}]`);
+        console.groupCollapsed(`${key} [${Object.keys(value).length}]`);
         const properties = Object.getOwnPropertyNames(ordered);
         _forEach(properties, o => {
           getType(o, value[o], level);
@@ -142,7 +141,7 @@ function getType(key, value, level = null) {
 }
 
 function loop(data, level) {
-  if (_size(data) === 1) {
+  if (Object.keys(data).length === 1) {
     _forEach(data[0], (val, key) => getType(key, val, level));
   } else {
     _forEach(data, (val, key) => getType(key, val, level));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clean_logs",
-  "version": "1.00.14",
+  "version": "1.00.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -112,11 +112,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "url": "https://github.com/pgiani/console-clean_logs/issues"
   },
   "homepage": "https://github.com/pgiani/clean_logs#readme",
-  "dependencies": {
-    "lodash": "^4.17.11"
-  },
   "devDependencies": {
     "mocha": "^4.0.1"
   }


### PR DESCRIPTION
Fully removed Lodash as a dependency.

Tested with the following object:

`{
  a: 'A',
  b: [1, 2, 3],
  c: {
    x: '',
    y: [1, 2, ['i', 'j', 'k']],
    z: {q: 'Q', r: {}}
  },
  d: {},
  e: null,
  f: moment('2016-01-01'),
  g: 123134,
  h: "sfsfsf"
}`

